### PR TITLE
Stop using reserved JavaScript keyword `arguments`

### DIFF
--- a/lib/blob-provider.js
+++ b/lib/blob-provider.js
@@ -106,7 +106,7 @@ export default {
     },
 
     getArgs(args){
-        var arguments = [];
+        var params = [];
         if (args != undefined)
         {
             for (variation of args)
@@ -161,13 +161,13 @@ export default {
                     }
                 }
 
-                arguments.push(snippet);
+                params.push(snippet);
             }
         }
 
-        else arguments = [""];
+        else params = [""];
 
-        return arguments;
+        return params;
     },
 
     match(name, string){


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!